### PR TITLE
Fix AttributeError When Accessing __name__ on Tuple

### DIFF
--- a/torch_flops/flops_engine.py
+++ b/torch_flops/flops_engine.py
@@ -417,7 +417,7 @@ class TorchFLOPsByFX():
 
             node_module_name = ''
             if (_var_name := 'nn_module_stack') in node.meta:
-                node_module_name = next(reversed(node.meta[_var_name].values())).__name__
+                node_module_name = next(reversed(node.meta[_var_name].values()))[1].__name__
                 # node_module_name = ".".join([_v.__name__ for _v in node.meta[_var_name].values()])
             _result_row.append(node_module_name)
 


### PR DESCRIPTION
Related to #16 

## Description

The expression ```next(reversed(node.meta[_var_name].values()))``` returns a tuple. Attempting to access the ```__name__``` attribute results in the following error:

```
AttributeError: 'tuple' object has no attribute '__name__'
```

## Reproduction

To reproduce the error, run the following code:

```python
import torch_flops

import torch
import torch.nn as nn

x = torch.randn([1, 100]).cuda()

model = nn.Sequential(nn.Linear(100, 1))
model = model.cuda()

with torch.no_grad():
    model(x)
flops_counter = torch_flops.TorchFLOPsByFX(model)
flops_counter.propagate(x)
flops_counter.print_total_flops(show=True)
```
 
## Error message
<img width="600" alt="Screenshot 2025-06-14 at 11 07 31 PM" src="https://github.com/user-attachments/assets/ba1f7f32-3b96-4c41-bdbc-43d0049ae0de" />

## Outcome

The proposed change resolves the issue. There is no change in behavior after the fix:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/f5b53ef2-e510-44f2-8d2c-615cd7c28920" />

## Package version

**Python** 3.11.13
**torch-flops** 0.3.6
**torch** 2.6.0+cu124